### PR TITLE
feat: defaut dateRange from URL

### DIFF
--- a/components/date-range-picker.tsx
+++ b/components/date-range-picker.tsx
@@ -7,7 +7,7 @@ import { format } from "date-fns"
 import { Icons } from "./icons"
 import { DateRange } from "react-day-picker"
 
-import { cn } from "@/lib/utils"
+import { cn, dateRangeParams } from "@/lib/utils"
 import { Button, buttonVariants } from "@/components/ui/button"
 import { Calendar } from "@/components/ui/calendar"
 import {
@@ -29,25 +29,6 @@ function urlDate(input: string): string {
   return `${year}-${formattedMonth}-${formattedDay}`
 }
 
-function getDateRangeFromUrl(searchParams: URLSearchParams): DateRange | undefined {
-  const from = searchParams.get('from');
-  const to = searchParams.get('to');
-
-  if (!from) {
-    return undefined;
-  }
-
-  const dateRange: DateRange = {
-    from: new Date(from),
-  };
-
-  if (to) {
-    dateRange.to = new Date(to);
-  }
-
-  return dateRange;
-}
-
 export function DateRangePicker({
   className,
 }: React.HTMLAttributes<HTMLDivElement>) {
@@ -55,7 +36,15 @@ export function DateRangePicker({
   const pathname = usePathname()
   const searchParams = useSearchParams();
 
-  const [date, setDate] = React.useState<DateRange | undefined>(getDateRangeFromUrl(searchParams))
+  const from = searchParams.get('from');
+  const to = searchParams.get('to');
+
+  const dateRange =  from && to ? dateRangeParams({
+    from,
+    to,
+  }): undefined;
+
+  const [date, setDate] = React.useState<DateRange | undefined>(dateRange)
 
   return (
     <div className={cn("flex gap-1", className)}>

--- a/components/date-range-picker.tsx
+++ b/components/date-range-picker.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { useRouter, usePathname } from "next/navigation"
+import { useRouter, usePathname, useSearchParams } from "next/navigation"
 
 import { format } from "date-fns"
 import { Icons } from "./icons"
@@ -29,12 +29,33 @@ function urlDate(input: string): string {
   return `${year}-${formattedMonth}-${formattedDay}`
 }
 
+function getDateRangeFromUrl(searchParams: URLSearchParams): DateRange | undefined {
+  const from = searchParams.get('from');
+  const to = searchParams.get('to');
+
+  if (!from) {
+    return undefined;
+  }
+
+  const dateRange: DateRange = {
+    from: new Date(from),
+  };
+
+  if (to) {
+    dateRange.to = new Date(to);
+  }
+
+  return dateRange;
+}
+
 export function DateRangePicker({
   className,
 }: React.HTMLAttributes<HTMLDivElement>) {
   const router = useRouter()
   const pathname = usePathname()
-  const [date, setDate] = React.useState<DateRange | undefined>()
+  const searchParams = useSearchParams();
+
+  const [date, setDate] = React.useState<DateRange | undefined>(getDateRangeFromUrl(searchParams))
 
   return (
     <div className={cn("flex gap-1", className)}>


### PR DESCRIPTION
I noticed that when refreshing the page after selecting a date range the component would show "Pick a date" even though the data being presented was still based on the previously selected range.

This PR grabs the url `searchParams` and sets the default selected `dateRange`.

I've got a few other things as well. Let me know if you're not accepting Issues or PRs. But, I'm a fan of how you've set things up and would like to extend some functionality :)