### PR TITLE
fix: format date function

### DIFF
--- a/components/activity/logs/logs-delete-button.tsx
+++ b/components/activity/logs/logs-delete-button.tsx
@@ -80,7 +80,7 @@ export function LogsDeleteButton({ logs }: LogsDeleteButtonProps) {
         <CredenzaContent>
           <CredenzaHeader>
             <CredenzaTitle>
-              Delete logs from {formatDate(logs.date.toDateString())}?
+              Delete logs from {formatDate(logs.date)}?
             </CredenzaTitle>
             <CredenzaDescription>
               This action cannot be undone.

--- a/components/activity/logs/logs-delete-button.tsx
+++ b/components/activity/logs/logs-delete-button.tsx
@@ -80,7 +80,7 @@ export function LogsDeleteButton({ logs }: LogsDeleteButtonProps) {
         <CredenzaContent>
           <CredenzaHeader>
             <CredenzaTitle>
-              Delete logs from {formatDate(logs.date.toLocaleDateString())}?
+              Delete logs from {formatDate(logs.date.toDateString())}?
             </CredenzaTitle>
             <CredenzaDescription>
               This action cannot be undone.

--- a/components/charts/heatmap.tsx
+++ b/components/charts/heatmap.tsx
@@ -138,10 +138,7 @@ export function Heatmap({ data, params }: HeatmapProps) {
             <CredenzaHeader>
               <CredenzaTitle>
                 Delete logs from{" "}
-                {selectedDate
-                  ? formatDate(selectedDate.toLocaleDateString())
-                  : ""}
-                ?
+                {selectedDate ? formatDate(selectedDate.toDateString()) : ""}?
               </CredenzaTitle>
               <CredenzaDescription>
                 This action cannot be undone.

--- a/components/charts/heatmap.tsx
+++ b/components/charts/heatmap.tsx
@@ -137,8 +137,7 @@ export function Heatmap({ data, params }: HeatmapProps) {
           <CredenzaContent>
             <CredenzaHeader>
               <CredenzaTitle>
-                Delete logs from{" "}
-                {selectedDate ? formatDate(selectedDate.toDateString()) : ""}?
+                Delete logs from {selectedDate ? formatDate(selectedDate) : ""}?
               </CredenzaTitle>
               <CredenzaDescription>
                 This action cannot be undone.

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -9,11 +9,11 @@ export function cn(...inputs: ClassValue[]) {
 
 export function formatDate(input: string | number): string {
   const date = new Date(input)
-  return Intl.DateTimeFormat("en-US", {
+  return date.toLocaleDateString("en-US", {
     month: "short",
     day: "numeric",
     year: "numeric",
-  }).format(date)
+  })
 }
 
 export function dateRangeParams(searchParams: { from: string; to: string }) {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -7,8 +7,8 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
-export function formatDate(input: string | number): string {
-  const date = new Date(input)
+export function formatDate(input: string | number | Date): string {
+  const date = input instanceof Date ? input : new Date(input)
   return date.toLocaleDateString("en-US", {
     month: "short",
     day: "numeric",


### PR DESCRIPTION
Added Date type in `formatDate` function input parameter and changed the formatter from `Intl.DateTimeFormat` to `date.toLocaleDateString`.

Removed	`toLocaleDateString` from delete alert messages to address issue #11 